### PR TITLE
Make options optional for start

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ var audio = new PassThrough;
 var info = new PassThrough;
 
 var start = function(options) {
+    options = options || {};
+    
     if(ps == null) {
         ps = spawn('arecord', ['-D', 'plughw:1,0', '-f', 'dat']);
         


### PR DESCRIPTION
In the readme, `startCapture` is called without arguments. This leads to an uncaught exception. This makes options optional.