### PR TITLE
Expand config object for startCapture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Information
 
 <table>
-<tr> 
+<tr>
 <td>Package</td><td>microphone</td>
 </tr>
 <tr>
@@ -24,9 +24,9 @@ This library need
 A simple example which capture sound and redirect it to stdout.
 
     var mic = require('microphone');
-    
+
     mic.startCapture();
-    
+
     mic.audioStream.on('data', function(data) {
         process.stdout.write(data);
     });
@@ -37,14 +37,21 @@ A simple example which capture sound and redirect it to stdout.
 
 Start the process and pipe the stdout of ALSA `arecord` tool to audioStream
 
-By default, the outputing sound are PCM WAVE format, if you want a MP3 format 
-pass `true` as `mp3Output` in the options passed in arguments. 
+By default, the outputing sound are PCM WAVE format, if you want a MP3 format
+pass `true` as `mp3Output` in the options passed in arguments.
 
 (Example : `mic.startCapture({'mp3output' : true});`)
 
+Other options which can be specified include:
+* alsa_format - Example: 'S16_LE' See arecord --help for a list of recognized formats.
+* alsa_device - Example: 'hw:1,0'
+* alsa_addn_args - Example: ['arg1', 'arg2']
+* sox_format - Example: 'dat'
+* sox_addn_args - Example: ['arg1', 'arg2']
+
 #### stopCapture();
 
-Stop the process 
+Stop the process
 
 #### audioStream
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,15 @@ pass `true` as `mp3Output` in the options passed in arguments.
 
 (Example : `mic.startCapture({'mp3output' : true});`)
 
-Other options which can be specified include:
-* alsa_format - Example: 'S16_LE' See arecord --help for a list of recognized formats.
-* alsa_device - Example: 'hw:1,0'
-* alsa_addn_args - Example: ['arg1', 'arg2']
-* sox_format - Example: 'dat'
-* sox_addn_args - Example: ['arg1', 'arg2']
+Other optional parameters in the options object include:
+* alsa_format - ALSA format to use for capture (Example: 'S16_LE' See arecord --help for a list of recognized formats)
+* alsa_device - ALSA device to capture from (Example: 'hw:1,0')
+* alsa_addn_args - Additional arguements for ALSA (Example: ['--rate', '16000'])
+* sox_format - SoX format to use for capture (Example: 'dat')
+* sox_addn_args - Additional arguements for SoX (Example: ['arg1', 'arg2'])
+* mp3_channels - Number of channels for the MP3 Encoder (Example: 2)
+* mp3_bitDepth - Bit Depth for the MP3 Encoder (Example: 16)
+* mp3_sampleRate - Sample Rate for the MP3 Encoder (Example: 44100)
 
 #### stopCapture();
 

--- a/index.js
+++ b/index.js
@@ -10,11 +10,16 @@ var info = new PassThrough;
 
 var start = function(options) {
     options = options || {};
-    
+    var alsa_format = options.alsa_format || 'dat',
+        alsa_device = options.alsa_device || 'plughw:1,0',
+        alsa_addn_args = options.alsa_addn_args || [],
+        sox_format = options.sox_format || 'dat',
+        sox_addn_args = options.sox_addn_args || [];
+
     if(ps == null) {
         ps = isMacOrWin
-        ? spawn('sox', ['-d', '-t', 'dat', '-p'])
-        : spawn('arecord', ['-D', 'plughw:1,0', '-f', 'dat']);
+        ? spawn('sox', ['-d', '-t', sox_format, '-p'].concat(sox_addn_args))
+        : spawn('arecord', ['-D', alsa_device, '-f', alsa_format].concat(alsa_addn_args));
 
         if(options.mp3output === true) {
             var encoder = new lame.Encoder( {

--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ var start = function(options) {
         alsa_device = options.alsa_device || 'plughw:1,0',
         alsa_addn_args = options.alsa_addn_args || [],
         sox_format = options.sox_format || 'dat',
-        sox_addn_args = options.sox_addn_args || [];
+        sox_addn_args = options.sox_addn_args || [],
+        mp3_channels = options.mp3_channels || 2,
+        mp3_bitDepth = options.mp3_bitDepth || 16,
+        mp3_sampleRate = options.mp3_sampleRate || 44100;
 
     if(ps == null) {
         ps = isMacOrWin
@@ -23,9 +26,9 @@ var start = function(options) {
 
         if(options.mp3output === true) {
             var encoder = new lame.Encoder( {
-                channels: 2,
-                bitDepth: 16,
-                sampleRate: 44100
+                channels: mp3_channels,
+                bitDepth: mp3_bitDepth,
+                sampleRate: mp3_sampleRate
             });
 
             ps.stdout.pipe(encoder);


### PR DESCRIPTION
I have expanded the config object for startCapture to allow for specifying bit rate, capture hardware, recording format, and any other optional argument which could be specified for the SoX and arecord applications. 

I have also partially resolved issue #3 by giving optional arguments for the MP3 Encoder in the options argument. 

README.md has been updated to show all the optional arguments. 
