### PR TITLE
Update to lame 1.2.3 - fixes compatibility w/ newer node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     }
   ],
   "dependencies": {
-    "lame": "1.0.3"
+    "lame": "1.2.3"
   },
   "devDependencies": {},
   "homepage": "http://github.com/vincentsaluzzo/node-microphone",


### PR DESCRIPTION
On node > 0.11.x lame will not install properly. Updating to newest lame version fixes this. The errors during installation were:

``` sh
8 warnings generated.
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/feature.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/dct64_x86_64.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/dct64_x86_64_float.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_s32.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_real.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_stereo_x86_64.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_stereo_x86_64_float.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_stereo_x86_64_s32.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_x86_64.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_x86_64_s32.o
  CC(target) Release/obj.target/mpg123/deps/mpg123/src/libmpg123/synth_x86_64_float.o
  LIBTOOL-STATIC Release/libmpg123.a
  CC(target) Release/obj.target/lamevectorroutines/deps/lame/libmp3lame/vector/xmm_quantize_sub.o
  LIBTOOL-STATIC Release/liblamevectorroutines.a
  CXX(target) Release/obj.target/bindings/src/bindings.o
../src/bindings.cc:29:15: error: calling a protected constructor of class 'v8::HandleScope'
  HandleScope scope;
              ^
/Users/jkaufman/.node-gyp/0.12.7/deps/v8/include/v8.h:816:13: note: declared protected here
  V8_INLINE HandleScope() {}
            ^
```
